### PR TITLE
Use constructor operation for PeriodicSyncEvent

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -281,10 +281,9 @@ dictionary PeriodicSyncEventInit : ExtendableEventInit {
     required DOMString tag;
 };
 
-[
-    Constructor(DOMString type, PeriodicSyncEventInit init),
-    Exposed=ServiceWorker
-] interface PeriodicSyncEvent : ExtendableEvent {
+[Exposed=ServiceWorker]
+interface PeriodicSyncEvent : ExtendableEvent {
+    constructor(DOMString type, PeriodicSyncEventInit init);
     readonly attribute DOMString tag;
   };
 </script>

--- a/index.bs
+++ b/index.bs
@@ -285,7 +285,7 @@ dictionary PeriodicSyncEventInit : ExtendableEventInit {
 interface PeriodicSyncEvent : ExtendableEvent {
     constructor(DOMString type, PeriodicSyncEventInit init);
     readonly attribute DOMString tag;
-  };
+};
 </script>
 
 <div dfn-for="PeriodicSyncEvent">


### PR DESCRIPTION
The Constructor extended attribute has been removed from Web IDL.